### PR TITLE
Remove hardcorded 'default' as plan name.

### DIFF
--- a/src/Concerns/ManagesSubscriptions.php
+++ b/src/Concerns/ManagesSubscriptions.php
@@ -175,7 +175,7 @@ trait ManagesSubscriptions
     {
         $this->assertCustomerExists();
 
-        $response = Paystack::api('GET', "subscription/{$this->subscription->paystack_code}/manage/link");
+        $response = Paystack::api("subscription/{$this->subscription()->paystack_code}/manage/link", 'GET');
 
         return $response['data']['link'];
     }

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -76,8 +76,7 @@ class WebhookController extends Controller
         if ($billable && ! isset($subscription)) {
             $plan = $data['plan'];
 
-            // To-do: default is currently hardcoded here and should not be
-            $builder = $billable->newSubscription('default', $plan['plan_code']);
+            $builder = $billable->newSubscription($plan['name'], $plan['plan_code']);
 
             $data['id'] = null;
 


### PR DESCRIPTION
Replaces `default` with `$plan['name']`